### PR TITLE
Add function to pull CCID from the account automatically, and mark th…

### DIFF
--- a/CSFalconInstall.sh
+++ b/CSFalconInstall.sh
@@ -3,9 +3,8 @@
 # Configuration - Add this before uploading - It's a shame that Intune doesn't have secrets support... :(
 CLIENT_ID=
 CLIENT_SECRET=
-CS_CCID=
-CS_INSTALL_TOKEN=
 BASE_URL= # Ex. https://api.crowdstrike.com, https://api.us-2.crowdstrike.com
+CS_INSTALL_TOKEN= # Optional if defined, prevents unauthorized additions via CCID
 
 if [[ $EUID -ne 0 ]]; then
     echo "This script must be run as root"
@@ -22,13 +21,19 @@ get_sha256() {
     echo "function run() { let result = JSON.parse(\`$json\`); return result.resources[0].sha256; }" | osascript -l JavaScript
 }
 
+get_ccid() {
+    json=$(curl -s -H "Authorization: Bearer ${1}" ${BASE_URL}/sensors/queries/installers/ccid/v1)
+    echo "function run() { let result = JSON.parse(\`$json\`); return result.resources; }" | osascript -l JavaScript
+}
+
 if [ ! -x "/Applications/Falcon.app/Contents/Resources/falconctl" ] || [ -z "$(/Applications/Falcon.app/Contents/Resources/falconctl stats | grep 'Sensor operational: true')" ]; then
     APITOKEN=$(get_access_token)
     FALCON_LATEST_SHA256=$(get_sha256 "${APITOKEN}")
+    CCID=$(get_ccid "${APITOKEN}")
     curl -o /tmp/FalconSensorMacOS.pkg -s -H "Authorization: Bearer ${APITOKEN}" ${BASE_URL}/sensors/entities/download-installer/v1?id=${FALCON_LATEST_SHA256}
     installer -verboseR -package /tmp/FalconSensorMacOS.pkg -target /
     rm /tmp/FalconSensorMacOS.pkg
-    /Applications/Falcon.app/Contents/Resources/falconctl license ${CS_CCID} ${CS_INSTALL_TOKEN} || true # Don't fail if the app is already licensed, but still needs a reinstall
+    /Applications/Falcon.app/Contents/Resources/falconctl license ${CCID} ${CS_INSTALL_TOKEN} || true # Don't fail if the app is already licensed, but still needs a reinstall
 else
     echo "Crowdstrike Falcon is installed and operational"
 fi


### PR DESCRIPTION
This pull creates a function to pull the CCID, and marks the INSTALL_TOKEN as optional since it's only needed if the CrowdStrike settings require it.